### PR TITLE
Set explicit CURLOPT_SSLVERSION to CURL_SSLVERSION_TLSv1_2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,15 @@
 language: php
 php:
-  - 5.3
-  - 5.4
   - 5.5
   - 5.6
   - hhvm
 install:
   - composer require satooshi/php-coveralls:~0.6@stable
 before_script:
-    - composer dump-autoload
-    - cp tests/fixtures.ini.example tests/fixtures.ini
+  - composer dump-autoload
+  - cp tests/fixtures.ini.example tests/fixtures.ini
 script:
-    - phpunit tests/
+  - phpunit tests/
 after_success:
   - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then php vendor/bin/coveralls -v; fi;'
 notifications:

--- a/composer.json
+++ b/composer.json
@@ -2,17 +2,22 @@
     "name": "everypay/everypay-php",
     "type": "library",
     "description": "",
-    "keywords": ["payment", "provider", "payment processing", "api"],
+    "keywords": [
+        "payment",
+        "provider",
+        "payment processing",
+        "api"
+    ],
     "license": "MIT",
     "homepage": "https://www.everypay.gr",
     "authors": [
-    {
-        "name": "EveryPay Payment Processing Gateway",
-        "homepage": "https://www.everypay.gr"
-    }
+        {
+            "name": "EveryPay Payment Processing Gateway",
+            "homepage": "https://www.everypay.gr"
+        }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.5.19",
         "ext-curl": "*",
         "ext-json": "*"
     },

--- a/src/AbstractResource.php
+++ b/src/AbstractResource.php
@@ -152,6 +152,7 @@ abstract class AbstractResource
         $client->setOption(CurlClient::TIMEOUT, 30);
         $client->setOption(CurlClient::SSL_VERIFY_PEER, 0);
         $client->setOption(CurlClient::USER_AGENT, 'EveryPay PHP Library ' . Everypay::VERSION);
+        $client->setOption(CurlClient::SSL_VERSION, CURL_SSLVERSION_TLSv1_2);
 
         return $client;
     }

--- a/src/Http/Client/CurlClient.php
+++ b/src/Http/Client/CurlClient.php
@@ -19,6 +19,7 @@ class CurlClient implements ClientInterface
     const TIMEOUT           = CURLOPT_TIMEOUT;
     const SSL_VERIFY_PEER   = CURLOPT_SSL_VERIFYPEER;
     const SSL_VERIFY_HOST   = CURLOPT_SSL_VERIFYHOST;
+    const SSL_VERSION       = CURLOPT_SSLVERSION;
     const USER_AGENT        = CURLOPT_USERAGENT;
 
     private $options = array(


### PR DESCRIPTION
On AbstractResource level, set explicit ssl version when initializing curl client to prevent breaking the http request due to ssl upgrade.